### PR TITLE
Output sensor information in a URDF-like format

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,11 @@ assignedInertias:
 ~~~
 
 ##### Sensors Parameters
-Sensor information can be expressed using arrays of sensor options:
+Sensor information can be expressed using arrays of sensor options. 
+Note that given that the URDF still does not support an official format for expressing sensor information, 
+this script will output two different elements for each sensor: 
+* a `<gazebo>` element, necessary to simulate the sensor in Gazebo when loading the URDF, as documented in http://gazebosim.org/tutorials?tut=ros_gzplugins . 
+* a more URDF-like `<sensor>` element, in particular the variant supported by the iDynTree library, as documented in https://github.com/robotology/idyntree/blob/master/doc/model_loading.md . 
 
 
 | Attribute name   | Type   | Default Value | Description  |


### PR DESCRIPTION
In addition to the already-supported Gazebo format.
As the discussion on how to support format in URDF is not progressing
(see https://github.com/ros/urdfdom/pull/28) for now support the dialect
used in iDynTree, as documented in https://github.com/robotology/idyntree/blob/master/doc/model_loading.md .

Necessary to properly solve  https://github.com/robotology/codyco-superbuild/issues/55#issuecomment-227872325 .