### PR TITLE
Fixed missing append of link sensor parameters to URDF

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,12 @@ language: python
 python:
 - "2.7"
 - "3.3"
+- "3.4"
+- "3.5"
 
 before_install:
 # install dependencies available on pip
-- pip install numpy lxml PyYAML --use-mirrors
+- pip install numpy lxml PyYAML
 # install urdf_parser_py
 - git clone https://github.com/ros/urdf_parser_py
 - cd urdf_parser_py

--- a/simmechanics_to_urdf/firstgen.py
+++ b/simmechanics_to_urdf/firstgen.py
@@ -252,6 +252,7 @@ class Converter:
             
             # Add sensor in URDF format 
             sensor_el =  generatorURDFSensors.getURDFSensor(sensorLink, sensorType, sensorName, urdf_origin_el)
+            self.urdf_xml.append(sensor_el);
 
 
 


### PR DESCRIPTION
As documented [here](https://github.com/robotology/idyntree/blob/master/doc/model_loading.md), the sensors parameters should also be defined for iDynTree under the `<sensor>` tag, and actually the script builds the chunk off data to add to the URDF but the actual line for adding is missing in the script. As a result, the __imu_frame__ was not generated in simmechanics models (https://github.com/robotology-playground/icub-model-generator/issues/17).