### PR TITLE
Add MTB and EMS sensors handling

### DIFF
--- a/simmechanics_to_urdf/firstgen.py
+++ b/simmechanics_to_urdf/firstgen.py
@@ -28,7 +28,7 @@ COLORS =[("green", (0, 1, 0, 1)), ("black", (0, 0, 0, 1)), ("red", (1, 0, 0, 1))
      ("dblue", (0, 0, .8, 1)), ("dgreen", (.1, .8, .1, 1)), ("gray", (.5, .5, .5, 1))]
      
 # List of supported sensor types
-SENSOR_TYPES = ["altimeter", "camera", "contact", "depth", "gps", "gpu_ray", "imu", "logical_camera",
+SENSOR_TYPES = ["altimeter", "camera", "contact", "depth", "gps", "gpu_ray", "imu", "accelerometer", "gyroscope", "logical_camera",
                 "magnetometer", "multicamera", "ray", "rfid", "rfidtag", "sonar", "wireless_receiver", "wireless_transmitter"]
                 
 # List of supported geometric shapes and their properties
@@ -138,6 +138,7 @@ class Converter:
         self.realRootLink = None
         self.outputString = "".encode('UTF-8')
         self.sensorIsValid = False
+        self.sensorsDefaultMap = {}
         # map mapping USERADDED linkName+displayName to fid of the frame
         self.linkNameDisplayName2fid = {}
 
@@ -146,6 +147,9 @@ class Converter:
 
         # Extra Transforms for Debugging
         self.tfman.add([0,0,0], [0.70682518,0,0,0.70682518], "ROOT", WORLD) # rotate so Z axis is up
+
+        # convert sensor type to gazebo respective sensor type
+        self.sensorTypeUrdf2sdf = {'imu':'imu','accelerometer':'imu','gyroscope':'imu'}
 
     def convert(self, filename, yaml_configfile, csv_configfile, mode, outputfile_name):
         self.mode = mode
@@ -244,7 +248,9 @@ class Converter:
 
             #sys.stderr.write("Processing link " + link['uid'] + "\n")
 
-            gazebo_sensor_el =  generatorGazeboSensors.getURDFSensor(sensorLink, sensorType, sensorName, pose, updateRate, sensorBlobs)
+            gazeboSensorType = self.sensorTypeUrdf2sdf[sensorType];
+
+            gazebo_sensor_el =  generatorGazeboSensors.getURDFSensor(sensorLink, gazeboSensorType, sensorName, pose, updateRate, sensorBlobs)
  
             self.urdf_xml.append(gazebo_sensor_el);
             
@@ -324,6 +330,31 @@ class Converter:
         #        exported_frame["frameName"]
             
  
+        # Get default parameters in "sensors" list
+        # As we build the list of default sensors, we track the
+        # respective references to remove from self.sensors
+        sensorsToRemove = [];
+        for sensor in self.sensors:
+            if( sensor.get("sensorName") == 'default' ):
+                # for caution, void frame names
+                sensor["frameName"] = None;
+                sensor["exportedFrameName"] = None;
+                # copy parameters
+                self.sensorsDefaultMap[sensor.get("sensorType")] = sensor.copy();
+                sensorsToRemove.append(sensor);
+
+        # Remove default sensor parameters objects from sensors list
+        for sensor in sensorsToRemove:
+            self.sensors.remove(sensor);
+
+        # Go again through the "sensors" list and replace unset values by the default ones
+        for sensor in self.sensors:
+            defaultSensor = self.sensorsDefaultMap.get(sensor.get("sensorType"));
+            if( defaultSensor is not None):
+                mergedSensor = defaultSensor.copy();
+                mergedSensor.update(sensor);
+                sensor.update(mergedSensor);
+
         for sensor in self.sensors:
             if( sensor["exportFrameInURDF"] ): 
                 exported_frame = {}

--- a/simmechanics_to_urdf/firstgen.py
+++ b/simmechanics_to_urdf/firstgen.py
@@ -248,7 +248,7 @@ class Converter:
 
             #sys.stderr.write("Processing link " + link['uid'] + "\n")
 
-            gazeboSensorType = self.sensorTypeUrdf2sdf[sensorType];
+            gazeboSensorType = self.sensorTypeUrdf2sdf.get(sensorType,sensorType);
 
             gazebo_sensor_el =  generatorGazeboSensors.getURDFSensor(sensorLink, gazeboSensorType, sensorName, pose, updateRate, sensorBlobs)
  


### PR DESCRIPTION
Most of the changes had been done for supporting the automatic generation of URDF-like and Gazebo-like sensor elements in the URDF models. In the YAML configuration files, the link sensors parameters are listed under the attribute "sensors" as described [here](https://github.com/robotology/simmechanics-to-urdf#sensors-parameters). For now, this list includes only the IMU type. As the full set of iCub inertial sensors (accelerometers and gyroscopes) is being appended to this list, and accelerometers support on Gazebo is being integrated, a few changes in the parser are missing for a full support of the sensor types "accelerometer" and "gyroscope":

#### Add "accelerometer" and "gyroscope" to the list of supported sensor types
We add the new types to the `SENSOR_TYPES` list.

#### Convert the sensor types in the YAML file to respective Gazebo sensor types
In the method `addSensors` (`main()-->con.convert()-->self.addSensors()`) we build the list URDF xml output `self.urdf_xml`. Each Gazebo like element is built by `generatorGazeboSensors.getURDFSensor()` and appended to `self.urdf_xml`. Before that we need to convert the types using the map `self.sensorTypeUrdf2sdf` defined as follows:

`{'imu'-->'imu','accelerometer'-->'imu','gyroscope'-->'imu'}`

(we've used a map for an easier extension or update due to Gazebo evolution).

#### Optimise the number of required parameters under the attribute "sensors"
 With dozens of accelerometers to add, we ought to minimise the parameters required for each sensor. For this purpose, we will use "default" sensors for defining common repetitive parameters: 1 default sensor is identified by the sensorName "default" and a sensor type. It sets the defaults for all sensors of that same type. We describe below the steps for processing and applying the defaults to the list:

1. Browse the sensors list `self.sensors`, parse the default sensors, filling the map `self.sensorsDefaultMap` which is indexed by sensor type
2. Remove the default sensor parameters objects from sensors list
3. Go again through the "sensors" list and replace the unset values by the default ones.

In steps 1 and 3, for safer operations use copy() and update() methods of the list data type (some more details or ideas in these links: [data structures](https://docs.python.org/2/tutorial/datastructures.html), [live_discussions](http://treyhunner.com/2016/02/how-to-merge-dictionaries-in-python/)).