### PR TITLE
Reorder URDF file elements for avoiding sdformat issue 164

### DIFF
--- a/simmechanics_to_urdf/firstgen.py
+++ b/simmechanics_to_urdf/firstgen.py
@@ -171,8 +171,8 @@ class Converter:
         if mode == "xml":
             #print("URDF model to print : \n " + str(self.result) + "\n" )
             self.generateXML()
-            self.addSensors()
             addXMLBlobs(self.XMLBlobs, self.urdf_xml)
+            self.addSensors()
             self.outputString = lxml.etree.tostring(self.urdf_xml,pretty_print=True)
             
         if mode == "graph":


### PR DESCRIPTION
This PR is a solution in the URDF generation workflow for avoiding an issue with the `urdf` to `sdf` converter (https://bitbucket.org/osrf/sdformat/issues/164). This late issue was causing **Gazebo** to crash as we loaded the iCub model (https://github.com/robotology-playground/icub-model-generator/issues/54).
The change here is to insert in the `URDF` file the **XML** blobs before the `<sensor>` tags. This way, if a blob with collision/bounce parameters is present, it will be added before the `<sensors>` tag. Check https://github.com/robotology-playground/icub-model-generator/issues/54 and https://bitbucket.org/osrf/sdformat/issues/164 for more details.