### PR TITLE
Add parsing of xml blobs in FT sensor gazebo elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ this script will output two different elements for each sensor:
 | `sensorName`      | String   | jointName | Name of the sensor, to be used in the output URDF file |
 | `exportFrameInURDF` | Bool   | False        | If true, export a fake URDF link whose frame is coincident with the sensor frame (as if the sensor frame was added to the `exportedFrames` array). | 
 | `exportedFrameName` | String | sensorName | Name of the URDF link exported by the `exportFrameInURDF` option | 
+| `sensorBlobs` | String | empty | Array of strings (possibly on multiple lines) represeting complex XML blobs that will be included as child of the `<sensor>` element of type "force_torque" | 
 
 Note that for now the FT sensors sensor frame is required to be coincident with child link frame, due 
 to URDF limitations. 

--- a/simmechanics_to_urdf/firstgen.py
+++ b/simmechanics_to_urdf/firstgen.py
@@ -211,10 +211,12 @@ class Converter:
                 sensorName = referenceJoint
             else:
                 sensorName = ftSens["sensorName"];
+            sensorBlobs = ftSens.get("sensorBlobs");
 
             # Add sensor in Gazebo format
             ft_gazebo_el = generatorGazeboSensors.getURDFForceTorque(referenceJoint, sensorName,
-                                                                     ftSens["directionChildToParent"])
+                                                                     ftSens["directionChildToParent"],
+                                                                     sensorBlobs)
             self.urdf_xml.append(ft_gazebo_el);
 
             # Add sensor in URDF format
@@ -1775,7 +1777,7 @@ class URDFGazeboSensorsGenerator:
     def __init__(self):
         self.dummy = ""
 
-    def getURDFForceTorque(self, jointName, sensorName, directionChildToParent, updateRate=100):
+    def getURDFForceTorque(self, jointName, sensorName, directionChildToParent, sensorBlobs, updateRate=100):
         gazebo_el = lxml.etree.Element("gazebo", reference=jointName)
         sensor_el = lxml.etree.SubElement(gazebo_el, "sensor")
         sensor_el.set("name", sensorName);
@@ -1792,6 +1794,8 @@ class URDFGazeboSensorsGenerator:
             measure_direction_el.text = "child_to_parent"
         else:
             measure_direction_el.text = "parent_to_child"
+
+        addXMLBlobs(sensorBlobs, sensor_el)
 
         return gazebo_el;
 


### PR DESCRIPTION
This change in `firstgen.py` implements the parsing of a new parameter field, `sensorBlobs`, in the FT sensors options `forceTorqueSensors:`, as done already for generic sensors. This blob is a complex XML setting that is included as a child of the FT sensor Gazebo element. We depict below an example of parameters that can be parsed from the `yaml` configuration file:
```
...
# Sensors options
forceTorqueSensors:
  - jointName: l_leg_ft_sensor
    directionChildToParent: Yes
    sensorBlobs:
    - |
        <plugin name="left_leg_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
          <yarpConfigurationFile>model://iCub/conf/FT/gazebo_icub_left_leg_ft.ini</yarpConfigurationFile>
        </plugin>
...
```
This PR also updates the Readme accordingly.