### PR TITLE
Increase epsilon.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,10 @@ The parameter accepted by the script are documented in the following.
 
 ##### Root Parameters
 | Attribute name   | Type   | Default Value | Description  |
-|:----------------:|:---------:|:------------:|:-------------:|
-| `root`             | String  | First body in the file | Changes the root body of the tree |
+|:----------------:|:------:|:------------:|:-------------:|
+| `root`           | String | First body in the file | Changes the root body of the tree |
+| `originXYZ`      |  List  | empty | Changes the position of the root body |
+| `originRPY`      |  List  | empty | Changes the orientation of the root body |
 
 ##### Frame Parameters 
 | Attribute name   | Type   | Default Value | Description  |

--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ The parameter accepted by the script are documented in the following.
 | `originXYZ`      |  List  | empty | Changes the position of the root body |
 | `originRPY`      |  List  | empty | Changes the orientation of the root body |
 
+##### Algorithm Parameters
+| Attribute name   | Type   | Default Value | Description  |
+|:----------------:|:------:|:-------------:|:-------------:|
+| `epsilon`        | Float | Machine *eps* | Set a custom value for testing whether a number is close to zero |
+
 ##### Frame Parameters 
 | Attribute name   | Type   | Default Value | Description  |
 |:----------------:|:---------:|:------------:|:-------------:|

--- a/simmechanics_to_urdf/firstgen.py
+++ b/simmechanics_to_urdf/firstgen.py
@@ -40,7 +40,7 @@ GEOMETRIC_SHAPES = {
     'sphere': ['origin', 'radius']}
 
 # epsilon for testing whether a number is close to zero
-EPS = 2e-7
+_EPS = 2e-7
 
 # axis sequences for Euler angles
 _NEXT_AXIS = [1, 2, 0, 1]

--- a/simmechanics_to_urdf/firstgen.py
+++ b/simmechanics_to_urdf/firstgen.py
@@ -40,7 +40,7 @@ GEOMETRIC_SHAPES = {
     'sphere': ['origin', 'radius']}
 
 # epsilon for testing whether a number is close to zero
-_EPS = numpy.finfo(float).eps * 4.0
+EPS = 2e-7
 
 # axis sequences for Euler angles
 _NEXT_AXIS = [1, 2, 0, 1]

--- a/simmechanics_to_urdf/firstgen.py
+++ b/simmechanics_to_urdf/firstgen.py
@@ -40,7 +40,7 @@ GEOMETRIC_SHAPES = {
     'sphere': ['origin', 'radius']}
 
 # epsilon for testing whether a number is close to zero
-_EPS = 2e-7
+_EPS = numpy.finfo(float).eps * 4.0
 
 # axis sequences for Euler angles
 _NEXT_AXIS = [1, 2, 0, 1]
@@ -312,6 +312,11 @@ class Converter:
 
         self.originXYZ = configuration.get('originXYZ', [0.0,0.0,0.0])
         self.originRPY = configuration.get('originRPY', [0.0,0.0,0.0])
+
+        epsilon = configuration.get('epsilon', None)
+        if (epsilon is not None):
+            global _EPS
+            _EPS = float(epsilon)
 
         self.forcelowercase = configuration.get('forcelowercase', True)
 


### PR DESCRIPTION
With the new iCub2.5+ model sometimes the check on the alignment of a frame with the joint axis fails because the error is greater than "numpy.finfo(float).eps * 4.0" but smaller than 2e-7.
  
  