### PR TITLE
Fix malformed link material element

### DIFF
--- a/simmechanics_to_urdf/firstgen.py
+++ b/simmechanics_to_urdf/firstgen.py
@@ -136,7 +136,6 @@ class Converter:
         self.names = {}
         self.colormap = {}
         self.colorindex = 0
-        self.usedcolors = {}
         self.ref2nameMap = {}
         self.realRootLink = None
         self.outputString = "".encode('UTF-8')
@@ -1033,11 +1032,7 @@ class Converter:
                 (cname, (r, g, b, a)) = self.getColor(linkdict['name'])
 
             visual.material.name = cname
-
-            # If color has already been output, only output name
-            if not cname in self.usedcolors:
-                visual.material.color = urdf_parser_py.urdf.Color(r, g, b, a)
-                self.usedcolors[cname] = True
+            visual.material.color = urdf_parser_py.urdf.Color(r, g, b, a)
 
             # Create a new gazebo blob for applying colors in the sdf
             gzblobmaterial_el = lxml.etree.Element("gazebo", reference=id)


### PR DESCRIPTION
The URDF "specification" ( http://wiki.ros.org/urdf )  and its "reference implementation" ( https://github.com/ros/urdfdom )  allow to have a material element without a color child element,
but only if the name of the color is specified in the model-wide material database.
Otherwise, it is always necessary to specify the color of the material of the link.

Fix https://github.com/robotology/icub-model-generator/issues/36
See https://github.com/robotology/icub-model-generator/issues/36#issuecomment-313065203

This should get rid of the terrible `[ERROR]  :: parseURDFMaterial : Impossible to parse URDF material, material black not found in model database.` warnings when loading an  iCub model generated with `simmechanics-to-urdf` . 