### PR TITLE
Document which valid version of urdf-parser-py is known to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,16 +34,21 @@ pip install lxml numpy pyyaml catkin_pkg
 ~~~
 
 #### Debian/Ubuntu
+
+**As the installation procedure at this moment suggest to install `pip` packages at the system level via administrative priviliges (such as `sudo`) at this moment it is suggest to follow it only on a dedicated environment, and not in your main development machine. See https://stackoverflow.com/a/22517157/1379427 for more details.**
+
+
 ##### Install dependencies
 Install the necessary dependencies with apt-get:
 ~~~
 sudo apt-get install python-lxml python-yaml python-numpy python-setuptools python-catkin-pkg
 ~~~
 
-You can install `urdf_parser_py` from its git repository:
+You can install `urdf_parser_py` from its git repository. Note that due to some regression in recent versions on the default branch of  `urdf_parser_py` (see https://github.com/robotology/simmechanics-to-urdf/issues/36) it is recommended to use a specific commit of `urdf_parser_py` that is known to work, https://github.com/ros/urdf_parser_py/commit/31474b9baaf7c3845b40e5a9aa87d5900a2282c3 :
 ~~~
 git clone https://github.com/ros/urdf_parser_py
 cd urdf_parser_py
+git checkout 31474b9baaf7c3845b40e5a9aa87d5900a2282c3
 sudo python setup.py install
 ~~~
 


### PR DESCRIPTION
Furthermore, add a warning on the risk of using `sudo pip` (eventually this should be solved by https://github.com/robotology/simmechanics-to-urdf/issues/46).

This should mitigate problems such as https://github.com/robotology/simmechanics-to-urdf/issues/47 or https://github.com/robotology/simmechanics-to-urdf/issues/41 until we fully fix https://github.com/robotology/simmechanics-to-urdf/issues/36 .