### PR TITLE
Fixed version number in setup.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.4.1] - 2022-12-20
+
+### Fixed
+
+- Fixed version number in setup.py ().
+
+## [0.4.0] - 2022-12-20
+
 ### Add
 - Add the possibility to assign the colors in the yaml file when the urdf model is generated (https://github.com/robotology/simmechanics-to-urdf/pull/51)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed version number in setup.py ().
+- Fixed version number in setup.py (https://github.com/robotology/simmechanics-to-urdf/pull/54).
 
 ## [0.4.0] - 2022-12-20
 

--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,11 @@ from setuptools import setup, find_packages
 
 
 setup(name='simmechanics_to_urdf',
-      version='0.3.0',
+      version='0.4.1',
       description='Converts SimMechanics XML to URDF',
       author='Silvio Traversaro, David V. Lu',
       author_email='pegua1@gmail.com',
-      url='https://github.com/robotology-playground/simmechanics-to-urdf',
+      url='https://github.com/robotology/simmechanics-to-urdf',
       packages=['simmechanics_to_urdf'],
       licence='BSD',
       classifiers=[


### PR DESCRIPTION
Fix the version number and the changelog that I overlooked when I tagged 0.4.0 : https://github.com/robotology/simmechanics-to-urdf/releases/tag/v0.4.0 .