### PR TITLE
Respect correctly assignedMass even if a link inertia is specified via mirroredInertia

### DIFF
--- a/simmechanics_to_urdf/firstgen.py
+++ b/simmechanics_to_urdf/firstgen.py
@@ -1348,16 +1348,28 @@ class Converter:
 
                 rpy = list(euler_from_quaternion(rot))
 
+                inertiaScaling = 1.0
+                if (id in self.assignedMasses):
+                    # if it is, we have to change the mass and scale
+                    # the inertia by multiplyng by new_mass/old_mass
+                    # (the COM instead don't need any modification)
+                    oldMass = inertial.mass;
+                    newMass = self.assignedMasses[id];
+                    inertial.mass = newMass;
+                    inertiaScaling = newMass / oldMass;
+
                 # Save inertia matrix
                 # sys.stderr.write("Inertia RPY of link " + str(id) + "is " + str(rpy) + "\n");
                 # sys.stderr.write("Inertia matrix of link " + str(id) + "is " + str(simmetryReferenceLink_Inertia) + "\n");
                 inertial.inertia = urdf_parser_py.urdf.Inertia()
-                inertial.inertia.ixx = simmetryReferenceLink_Inertia[0, 0];
-                inertial.inertia.ixy = simmetryReferenceLink_Inertia[0, 1];
-                inertial.inertia.ixz = simmetryReferenceLink_Inertia[0, 2];
-                inertial.inertia.iyy = simmetryReferenceLink_Inertia[1, 1];
-                inertial.inertia.iyz = simmetryReferenceLink_Inertia[1, 2]
-                inertial.inertia.izz = simmetryReferenceLink_Inertia[2, 2];
+                inertial.inertia.ixx = inertiaScaling*simmetryReferenceLink_Inertia[0, 0];
+                inertial.inertia.ixy = inertiaScaling*simmetryReferenceLink_Inertia[0, 1];
+                inertial.inertia.ixz = inertiaScaling*simmetryReferenceLink_Inertia[0, 2];
+                inertial.inertia.iyy = inertiaScaling*simmetryReferenceLink_Inertia[1, 1];
+                inertial.inertia.iyz = inertiaScaling*simmetryReferenceLink_Inertia[1, 2]
+                inertial.inertia.izz = inertiaScaling*simmetryReferenceLink_Inertia[2, 2];
+
+
 
                 # Save COM and Inertia orientation
                 inertial.origin = urdf_parser_py.urdf.Pose(zero(off), zero(rpy))


### PR DESCRIPTION
This ensure that if a link has both assignedMass and mirroredInertia, assignedMass is not ignored.

Fix https://github.com/robotology/simmechanics-to-urdf/issues/58 .



This is not the perfect fix as ideally we would like for mirroredInertia to get the assignedMass from the link from which we copy the inertia parameters. However, this requires some more code changes that I do not have the time to do now, especially given that the work on the lab has been shifted to https://github.com/icub-tech-iit/creo2urdf . 